### PR TITLE
Fix/co 376 invalid cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 .classpath
 .idea
+.ivy2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                         cat <<EOF > build.properties
                         debug=0
                         is-production=1
-                        carbonio.buildinfo.version=22.5.0_ZEXTRAS_202205
+                        carbonio.buildinfo.version=22.9.0_ZEXTRAS_202209
                         EOF
                        '''
                     sh "cat ${CREDENTIALS} | sed -E 's#\\\\#\\\\\\\\#g' >> build.properties"
@@ -51,7 +51,7 @@ pipeline {
                         cat <<EOF > build.properties
                         debug=0
                         is-production=1
-                        carbonio.buildinfo.version=22.5.0_ZEXTRAS_202205
+                        carbonio.buildinfo.version=22.9.0_ZEXTRAS_202209
                         EOF
                        '''
                     sh "cat ${CREDENTIALS} | sed -E 's#\\\\#\\\\\\\\#g' >> build.properties"

--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -14,7 +14,7 @@
   <credentials host="zextras.jfrog.io" realm="Artifactory Realm" username="${artifactory_user}" passwd="${artifactory_password}" />
 
   <settings defaultResolver="chain-resolver" />
-  <caches defaultCacheDir="${dev.home}/.ivy2/cache" />
+  <caches defaultCacheDir="${basedir}/.ivy2/cache" />
   <resolvers>
     <chain name="chain-resolver" returnFirst="true">
       <filesystem name="local">
@@ -23,12 +23,7 @@
         <artifact pattern="${dev.home}/.zcs-deps/[organisation].[ext]" />
 
       </filesystem>
-      <url name="maven-https-org">
-        <artifact pattern="https://repo1.maven.org/maven2/[organization]/[module]/[revision]/[artifact]-[revision].[ext]" />
-      </url>
-      <url name="maven-https-orgPath">
-        <artifact pattern="https://repo1.maven.org/maven2/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]" />
-      </url>
+      <ibiblio name="maven" m2compatible="true"/>
       <ibiblio name="public-maven" m2compatible="true" root="https://zextras.jfrog.io/artifactory/public-maven-repo" />
       <ibiblio name="maven-redhat" root="https://maven.repository.redhat.com/ga/" pattern="[organisation]/[module]/[revision]/[module]-[revision].[ext]" />
       <url name="liferay-https-orgPath">

--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -14,7 +14,7 @@
   <credentials host="zextras.jfrog.io" realm="Artifactory Realm" username="${artifactory_user}" passwd="${artifactory_password}" />
 
   <settings defaultResolver="chain-resolver" />
-  <caches defaultCacheDir="${basedir}/.ivy2/cache" />
+  <caches defaultCacheDir="${dev.home}/.ivy2/cache" />
   <resolvers>
     <chain name="chain-resolver" returnFirst="true">
       <filesystem name="local">

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,6 +1,7 @@
 <ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
     <info organisation="zimbra" module="zm-certificate-manager-store" status="integration"></info>
     <dependencies>
+        <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
         <dependency org="junit" name="junit" rev="4.8.2" />
         <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
         <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -16,7 +16,6 @@
         <dependency org="junit" name="junit" rev="4.8.2" conf="test" />
         <dependency org="org.mockito" name="mockito-core" rev="4.4.0" conf="test"/>
         <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
-        <dependency org="log4j" name="log4j" rev="1.2.16"/>
         <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
         <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
         <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,9 +1,15 @@
 <ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
     <info organisation="zimbra" module="zm-certificate-manager-store" status="integration"/>
+    <configurations defaultconfmapping="*->default">
+        <conf name="default" description="Default"/>
+        <conf name="compile" description="Compile dependencies"/>
+        <conf name="runtime" description="Runtime dependencies" extends="compile"/>
+        <conf name="test" description="Test dependencies" extends="runtime"/>
+    </configurations>
     <dependencies>
         <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
-        <dependency org="junit" name="junit" rev="4.8.2" />
-        <dependency org="org.mockito" name="mockito-core" rev="4.4.0"/>
+        <dependency org="junit" name="junit" rev="4.8.2" conf="test" />
+        <dependency org="org.mockito" name="mockito-core" rev="4.4.0" conf="test"/>
         <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
         <dependency org="log4j" name="log4j" rev="1.2.16"/>
         <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,9 +1,11 @@
 <ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
-    <info organisation="zimbra" module="zm-certificate-manager-store" status="integration"></info>
+    <info organisation="zimbra" module="zm-certificate-manager-store" status="integration"/>
     <dependencies>
         <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" />
         <dependency org="junit" name="junit" rev="4.8.2" />
+        <dependency org="org.mockito" name="mockito-core" rev="4.4.0"/>
         <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
+        <dependency org="log4j" name="log4j" rev="1.2.16"/>
         <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
         <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
         <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,5 +1,10 @@
 <ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
     <info organisation="zimbra" module="zm-certificate-manager-store" status="integration"/>
+    <!-- See: https://ant.apache.org/ivy/history/2.3.0/ivyfile/configurations.html for documentation
+    The idea is to always download the default maven configuration on remote repo.
+    By default, without configuration mapping, Ivy tries to download content for all configurations (sources, javadoc, etc.)
+    but some libraries, as ant, do not ship it, so the build fails. This can be refined for specific dependencies
+    but for now it is safe to download always the default -->
     <configurations defaultconfmapping="*->default">
         <conf name="default" description="Default"/>
         <conf name="compile" description="Compile dependencies"/>

--- a/src/java-test/com/zimbra/cert/VerifyCertKeyTest.java
+++ b/src/java-test/com/zimbra/cert/VerifyCertKeyTest.java
@@ -1,0 +1,116 @@
+package com.zimbra.cert;
+
+import static com.zimbra.common.soap.CertMgrConstants.A_verifyResult;
+import static com.zimbra.common.soap.CertMgrConstants.VERIFY_CERTKEY_REQUEST;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.zimbra.cert.util.ProcessStarter;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.CertMgrConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.XMLElement;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.admin.message.VerifyCertKeyRequest;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class VerifyCertKeyTest {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test(expected = ServiceException.class)
+  public void shouldReturnInvalidIfPvtKeyEmpty() throws Exception {
+    final VerifyCertKey verifyCertKey = new VerifyCertKey(
+        mock(ProcessStarter.class), testFolder.getRoot().getAbsolutePath());
+    final Process processMock = mock(Process.class);
+    // prepare request
+    Map<String, Object> context = new HashMap<String, Object>();
+    ZimbraSoapContext zsc =
+        new ZimbraSoapContext(
+            mock(AuthToken.class),
+            "1",
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+    final XMLElement request = new XMLElement(VERIFY_CERTKEY_REQUEST);
+    request.addUniqueElement("cert").addText("test");
+    request.addUniqueElement("privKey").addText("");
+    verifyCertKey.handle(request, context);
+  }
+
+  @Test
+  public void shouldReturnTrueIfNoErrorInProcess() throws Exception {
+    final ProcessStarter processStarter = mock(ProcessStarter.class);
+    final VerifyCertKey verifyCertKey = new VerifyCertKey(processStarter, testFolder.getRoot().getAbsolutePath());
+    final Process processMock = mock(Process.class);
+    when(processStarter.start(any())).thenReturn(processMock);
+    when(processMock.waitFor()).thenReturn(1);
+    final ByteArrayInputStream mockProcessResult = new ByteArrayInputStream(
+        "The process went smooth".getBytes(StandardCharsets.UTF_8));
+    when(processMock.getInputStream()).thenReturn(mockProcessResult);
+    // prepare request
+    Map<String, Object> context = new HashMap<String, Object>();
+    ZimbraSoapContext zsc =
+        new ZimbraSoapContext(
+            mock(AuthToken.class),
+            "1",
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+    final XMLElement request = new XMLElement(VERIFY_CERTKEY_REQUEST);
+    request.addAttribute(CertMgrConstants.E_cert,"test");
+    request.addAttribute(CertMgrConstants.A_privkey, "test2");
+    final Element result = verifyCertKey.handle(request, context);
+    assertEquals("1", result.getAttribute(A_verifyResult));
+  }
+
+  @Test
+  public void shouldReturnFalseIfErrorInProcess() throws Exception {
+    final ProcessStarter processStarter = mock(ProcessStarter.class);
+    final VerifyCertKey verifyCertKey = new VerifyCertKey(processStarter, testFolder.getRoot().getAbsolutePath());
+    final Process processMock = mock(Process.class);
+    when(processStarter.start(any())).thenReturn(processMock);
+    when(processMock.waitFor()).thenReturn(1);
+    final ByteArrayInputStream mockProcessResult = new ByteArrayInputStream(
+        "Error: The process did not go very smooth".getBytes(StandardCharsets.UTF_8));
+    when(processMock.getInputStream()).thenReturn(mockProcessResult);
+    // prepare request
+    Map<String, Object> context = new HashMap<String, Object>();
+    ZimbraSoapContext zsc =
+        new ZimbraSoapContext(
+            mock(AuthToken.class),
+            "1",
+            SoapProtocol.Soap12,
+            SoapProtocol.Soap12);
+    context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+    final XMLElement request = new XMLElement(VERIFY_CERTKEY_REQUEST);
+    request.addAttribute(CertMgrConstants.E_cert,"test");
+    request.addAttribute(CertMgrConstants.A_privkey, "test2");
+    final Element result = verifyCertKey.handle(request, context);
+    assertEquals("0", result.getAttribute(A_verifyResult));
+  }
+
+}

--- a/src/java-test/com/zimbra/cert/VerifyCertKeyTest.java
+++ b/src/java-test/com/zimbra/cert/VerifyCertKeyTest.java
@@ -144,8 +144,8 @@ public class VerifyCertKeyTest {
   }
 
   /**
-   * If the input has more than one space in between headers or,
-   * the result should be different from a proper-formatted files.
+   * If the input has more than one space in between headers or content,
+   * the result should be different from a proper well-formatted certificate file.
    */
   @Test
   public void shouldNotMatchExpectedContentWhenInputMalformed() {

--- a/src/java/com/zimbra/cert/VerifyCertKey.java
+++ b/src/java/com/zimbra/cert/VerifyCertKey.java
@@ -128,7 +128,7 @@ public class VerifyCertKey extends AdminDocumentHandler {
    * Parses the command output and checks if it was successful based on displayed information.
    *
    * @param commandResult the received command result
-   * @return if successful
+   * @return if command was successful
    */
   private boolean verifyCrtCommandResult(String commandResult) {
     return !StringUtils.containsIgnoreCase(commandResult, "error");

--- a/src/java/com/zimbra/cert/VerifyCertKey.java
+++ b/src/java/com/zimbra/cert/VerifyCertKey.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang.StringUtils;
  * NOTE: The provided content is formatted by replacing spaces with newlines, for cases such as
  * copy-paste from a terminal. This should be taken in consideration when calling the API, as
  * zmcertmgr may fail if the content is not as expected.
+ * It has been tested though that spaces before or after headers do not affect the result.
+ * Additional spaces in the base64 content instead cause the verification to fail.
  */
 public class VerifyCertKey extends AdminDocumentHandler {
 

--- a/src/java/com/zimbra/cert/VerifyCertKey.java
+++ b/src/java/com/zimbra/cert/VerifyCertKey.java
@@ -5,156 +5,135 @@
 
 package com.zimbra.cert;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Map;
-
-import com.zimbra.common.localconfig.LC;
+import com.zimbra.cert.util.ProcessStarter;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.CertMgrConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.ByteUtil;
 import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.ldap.LdapUtil;
-import com.zimbra.cs.rmgmt.RemoteManager;
-import com.zimbra.cs.rmgmt.RemoteResult;
 import com.zimbra.cs.service.admin.AdminDocumentHandler;
 import com.zimbra.soap.ZimbraSoapContext;
-import org.apache.commons.lang.ArrayUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
+/**
+ * Verifies provided private key and certificate against the server using zmcertmgr verifycrt.
+ * It also verifies the chain certificate as it was issued by this server itself.
+ */
 public class VerifyCertKey extends AdminDocumentHandler {
-        final static String CERT_TYPE_SELF= "self" ;
-        final static String CERT_TYPE_COMM = "comm" ;
-    	private Provisioning prov = null;
-	private boolean verifyResult = false;
 
-    @Override
-    public Element handle(Element request, Map<String, Object> context) throws ServiceException {
-        ZimbraSoapContext lc = getZimbraSoapContext(context);
-        prov = Provisioning.getInstance();
-        String certBuffer = request.getAttribute(CertMgrConstants.E_cert);
-        String prvkeyBuffer = request.getAttribute(CertMgrConstants.A_privkey);
-        Element response = lc.createElement(CertMgrConstants.VERIFY_CERTKEY_RESPONSE);
+  final static String VERIFY_CERT_COMMAND = "verifycrt";
+  final static String CERT_MGR = "/opt/zextras/bin/zmcertmgr";
+  final static String CERT_TYPE_COMM = "comm";
 
-        String storedPath = LC.zimbra_tmp_directory.value() + File.separator + LdapUtil.generateUUID() + File.separator;
-        String keyFile = storedPath + ZimbraCertMgrExt.COMM_CRT_KEY_FILE_NAME;
-        String certFile = storedPath + ZimbraCertMgrExt.COMM_CRT_FILE_NAME;
-        String caFile = storedPath + ZimbraCertMgrExt.COMM_CRT_CA_FILE_NAME;
+  private final ProcessStarter processStarter;
+  private final String baseOperationPath;
 
-		try {
-   			if(certBuffer == null) {
-   				throw ServiceException.INVALID_REQUEST("Input Certificate is null", null);
-   			}
-   			if(prvkeyBuffer == null) {
-   				throw ServiceException.INVALID_REQUEST("Input PrivateKey is null",null);
-   			}
-			
-			// replace the space character with '\n'
-			String certBuffer_t = stringFix(certBuffer,true);
-			String prvkeyBuffer_t = stringFix(prvkeyBuffer,false);
+  public VerifyCertKey(ProcessStarter baseProcess, String baseOperationPath) {
+    this.processStarter = baseProcess;
+    this.baseOperationPath = baseOperationPath;
+  }
 
-			if(certBuffer_t.length() == 0 || prvkeyBuffer_t.length() == 0) {
-				// invalid certificate or privkey, return invalid
-				response.addAttribute(CertMgrConstants.A_verifyResult, "invalid");
-				return response;
-			}
+  @Override
+  public Element handle(Element request, Map<String, Object> context) throws ServiceException {
+    ZimbraSoapContext lc = getZimbraSoapContext(context);
+    String certBuffer = request.getAttribute(CertMgrConstants.E_cert);
+    String pvtKeyBuffer = request.getAttribute(CertMgrConstants.A_privkey);
+    Element response = lc.createElement(CertMgrConstants.VERIFY_CERTKEY_RESPONSE);
+    boolean verifyResult = false;
+    final String keyFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_KEY_FILE_NAME;
+    final String certFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_FILE_NAME;
+    final String caFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_CA_FILE_NAME;
 
-			byte [] certByte = certBuffer_t.getBytes();
+    try {
+      // replace the space character with '\n'
+      String sanitizedCrt = formatWithNewLine(certBuffer);
+      String sanitizedPvtKey = formatWithNewLine(pvtKeyBuffer);
 
-            File comm_path = new File(storedPath);
-            if (!comm_path.exists()) {
-                if (!comm_path.mkdirs()) {
-                    throw ServiceException.FAILURE("Cannot create dir " + comm_path.getAbsolutePath().toString(), null);
-                }
-            } else if (!comm_path.isDirectory()) {
-                throw ServiceException.FAILURE("Path is not a directory: " + comm_path.getAbsolutePath().toString(),
-                        null);
-            }
-			ByteUtil.putContent(certFile, certByte);
-			ByteUtil.putContent(caFile, certByte);
+      if (sanitizedCrt.length() == 0 || sanitizedPvtKey.length() == 0) {
+        response.addAttribute(CertMgrConstants.A_verifyResult, "invalid");
+        return response;
+      }
 
-			byte [] prvkeyByte = prvkeyBuffer_t.getBytes();
-			ByteUtil.putContent(keyFile, prvkeyByte) ;
+      // store pvt key, crt and ca in a temporary file
+      byte[] crtBytes = sanitizedCrt.getBytes();
+      byte[] pvtKeyBytes = sanitizedPvtKey.getBytes();
 
-			final Process zmCertMgrProcess = new ProcessBuilder("/opt/zextras/bin/zmcertmgr", "verifycrt", "comm",
-					keyFile, certFile, caFile).start();
-			final byte[] inputBytes = zmCertMgrProcess.getInputStream().readAllBytes();
-			final byte[] errBytes = zmCertMgrProcess.getErrorStream().readAllBytes();
-			verifyResult = OutputParser.parseVerifyResult(ArrayUtils.addAll(inputBytes,errBytes));
-			ZimbraLog.security.info(" GetVerifyCertResponse:" + verifyResult);
-		}catch (IOException ioe) {
-			throw ServiceException.FAILURE("IOException occurred while running cert verification command", ioe);
-		}
+      final String tmpPath = baseOperationPath + LdapUtil.generateUUID() + File.separator;
+      File comm_path = new File(tmpPath);
+      if (!comm_path.exists()) {
+        if (!comm_path.mkdirs()) {
+          throw ServiceException.FAILURE(
+              "Cannot create dir " + comm_path.getAbsolutePath(), null);
+        }
+      } else if (!comm_path.isDirectory()) {
+        throw ServiceException.FAILURE(
+            "Path is not a directory: " + comm_path.getAbsolutePath(),
+            null);
+      }
 
-            	try {
+      ByteUtil.putContent(certFile, crtBytes);
+      ByteUtil.putContent(caFile, crtBytes);
+      ByteUtil.putContent(keyFile, pvtKeyBytes);
 
-                	File comm_priv = new File (keyFile);
-	                if (!comm_priv.delete()) {
-        	             throw new SecurityException ("Deleting commercial private key file failed.")  ;
-                	}
-                        File comm_cert = new File (certFile);
-                        if (!comm_cert.delete()) {
-                             throw new SecurityException ("Deleting commercial certificate file failed.")  ;
-                        }
-                        File comm_ca = new File (caFile);
-                        if (!comm_ca.delete()) {
-                             throw new SecurityException ("Deleting commercial CA certificate file failed.")  ;
-                        }
+      final Process zmCertMgrProcess = processStarter.start(CERT_MGR, VERIFY_CERT_COMMAND,
+          CERT_TYPE_COMM,
+          keyFile, certFile, caFile);
+      verifyResult = this.verifyCrtCommandResult(
+          new String(zmCertMgrProcess.getInputStream().readAllBytes()));
+      ZimbraLog.security.info(" GetVerifyCertResponse:" + verifyResult);
 
-			File comm_path = new File(storedPath);
-			if(!comm_path.delete()) {
-			     throw new SecurityException ("Deleting directory of certificate/key failed.")  ;
-			}
+      File comm_priv = new File(keyFile);
+      if (!comm_priv.delete()) {
+        throw new SecurityException("Deleting commercial private key file failed.");
+      }
+      File comm_cert = new File(certFile);
+      if (!comm_cert.delete()) {
+        throw new SecurityException("Deleting commercial certificate file failed.");
+      }
+      File comm_ca = new File(caFile);
+      if (!comm_ca.delete()) {
+        throw new SecurityException("Deleting commercial CA certificate file failed.");
+      }
 
- 	        }catch (SecurityException se) {
-        	        ZimbraLog.security.error ("File(s) of commercial certificates/prvkey was not deleted", se ) ;
-            	}
+      if (!comm_path.delete()) {
+        throw new SecurityException("Deleting directory of certificate/key failed.");
+      }
 
-		if(verifyResult)
-	        	response.addAttribute(CertMgrConstants.A_verifyResult, "true");
-		else response.addAttribute(CertMgrConstants.A_verifyResult, "false");
-	        return response;
+    } catch (SecurityException se) {
+      ZimbraLog.security.error("File(s) of commercial certificates/prvkey was not deleted", se);
+    } catch (IOException ioe) {
+      throw ServiceException.FAILURE("IOException occurred while running cert verification command",
+          ioe);
+    }
 
-  		
-   	}
+    response.addAttribute(CertMgrConstants.A_verifyResult, verifyResult);
+    return response;
+  }
 
-	private String stringFix(String in, boolean isCert) {
-		if(in.length() < 0) return new String("");
+  /**
+   * Replaces spaces with new lines.
+   *
+   * @param input input string
+   * @return formatted string
+   */
+  private String formatWithNewLine(String input) {
+    return input.replaceAll("\\s", "\n");
+  }
 
-		String HEADER_CERT = "-----BEGIN CERTIFICATE-----";
-		String END_CERT = "-----END CERTIFICATE-----";
-		String HEADER_KEY = "-----BEGIN PRIVATE KEY-----";
-		String END_KEY = "-----END PRIVATE KEY-----";
-		String header, end;
-		String out = new String("");;
-		
-		if(isCert){
-			header = HEADER_CERT;
-			end = END_CERT;
-		}else {
-			header = HEADER_KEY;
-			end = END_KEY;
-		}
-			
-		String [] strArr = in.split(end);
-		for(int i = 0; i < strArr.length; i++){
-			int l = strArr[i].indexOf(header);
-			if(l == -1) continue;
-			String subStr = strArr[i].substring(l + header.length());
-			String repStr = subStr.replace(' ','\n');
-			out += (header + repStr + end + "\n");
-		}
-		return out;
-		
-	}
-	
-	private String getCurrentTimeStamp() {
-		SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd.HHmmss.SSS");
-		return 	fmt.format(new Date());
-	}
+  /**
+   * Parses the command output and checks if it was successful based on displayed information.
+   *
+   * @param commandResult the received command result
+   * @return if successful
+   */
+  private boolean verifyCrtCommandResult(String commandResult) {
+    return !StringUtils.containsIgnoreCase(commandResult, "error");
+  }
+
 }
 
 

--- a/src/java/com/zimbra/cert/VerifyCertKey.java
+++ b/src/java/com/zimbra/cert/VerifyCertKey.java
@@ -57,9 +57,10 @@ public class VerifyCertKey extends AdminDocumentHandler {
     String pvtKeyBuffer = request.getAttribute(CertMgrConstants.A_privkey);
     Element response = lc.createElement(CertMgrConstants.VERIFY_CERTKEY_RESPONSE);
     boolean verifyResult = false;
-    final String keyFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_KEY_FILE_NAME;
-    final String certFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_FILE_NAME;
-    final String caFile = baseOperationPath + ZimbraCertMgrExt.COMM_CRT_CA_FILE_NAME;
+    final String tmpPath = baseOperationPath + LdapUtil.generateUUID() + File.separator;
+    final String keyFile = tmpPath + ZimbraCertMgrExt.COMM_CRT_KEY_FILE_NAME;
+    final String certFile = tmpPath + ZimbraCertMgrExt.COMM_CRT_FILE_NAME;
+    final String caFile = tmpPath + ZimbraCertMgrExt.COMM_CRT_CA_FILE_NAME;
 
     try {
       // replace the space character with '\n'
@@ -75,7 +76,6 @@ public class VerifyCertKey extends AdminDocumentHandler {
       byte[] crtBytes = sanitizedCrt.getBytes();
       byte[] pvtKeyBytes = sanitizedPvtKey.getBytes();
 
-      final String tmpPath = baseOperationPath + LdapUtil.generateUUID() + File.separator;
       File comm_path = new File(tmpPath);
       if (!comm_path.exists()) {
         if (!comm_path.mkdirs()) {

--- a/src/java/com/zimbra/cert/ZimbraCertMgrService.java
+++ b/src/java/com/zimbra/cert/ZimbraCertMgrService.java
@@ -5,9 +5,12 @@
 
 package com.zimbra.cert;
 
+import com.zimbra.cert.util.ProcessStarterProvider;
+import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.soap.CertMgrConstants;
 import com.zimbra.soap.DocumentDispatcher;
 import com.zimbra.soap.DocumentService;
+import java.io.File;
 
 
 public class ZimbraCertMgrService implements DocumentService {
@@ -17,7 +20,8 @@ public class ZimbraCertMgrService implements DocumentService {
         dispatcher.registerHandler(CertMgrConstants.GET_CERT_REQUEST, new GetCert());
         dispatcher.registerHandler(CertMgrConstants.GEN_CSR_REQUEST, new GenerateCSR());
         dispatcher.registerHandler(CertMgrConstants.GET_CSR_REQUEST, new GetCSR());
-	    dispatcher.registerHandler(CertMgrConstants.VERIFY_CERTKEY_REQUEST, new VerifyCertKey());
+	    dispatcher.registerHandler(CertMgrConstants.VERIFY_CERTKEY_REQUEST, new VerifyCertKey(
+          new ProcessStarterProvider(), LC.zimbra_tmp_directory.value() + File.separator));
         dispatcher.registerHandler(CertMgrConstants.UPLOAD_DOMCERT_REQUEST, new UploadDomCert());
         dispatcher.registerHandler(CertMgrConstants.UPLOAD_PROXYCA_REQUEST, new UploadProxyCA());
     }

--- a/src/java/com/zimbra/cert/util/ProcessStarter.java
+++ b/src/java/com/zimbra/cert/util/ProcessStarter.java
@@ -1,0 +1,12 @@
+package com.zimbra.cert.util;
+
+public interface ProcessStarter {
+
+  /**
+   * Starts a process using given args.
+   * Example: start("/bin/bash", "my_beautiful_script.sh", "myBeautifulValue")
+   * @return the started process
+   */
+  Process start(String ...args);
+
+}

--- a/src/java/com/zimbra/cert/util/ProcessStarterProvider.java
+++ b/src/java/com/zimbra/cert/util/ProcessStarterProvider.java
@@ -1,0 +1,19 @@
+package com.zimbra.cert.util;
+
+import java.io.IOException;
+
+/**
+ * {@link ProcessStarter} implementation for real OS using {@link ProcessBuilder}
+ * @author davidefrison
+ */
+public class ProcessStarterProvider implements ProcessStarter {
+
+  @Override
+  public Process start(String ...args) {
+    try {
+      return new ProcessBuilder(args).start();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
### Goal

The API VerifyCertKey is broken, as it always returns invalid.
This fix addresses some problems, such as:

- parsing only private keys with header BEGIN PRIVATE RSA KEY (e.g.: BEGIN PRIVATE KEY does not work)
- using remote manager to ssh in to the server itself to run zmcertmgr command

### What's changed
- The API works as a proxy, it writes some .key, .crt and _ca.crt files locally and then uses zmcertmgr to verify them, just like as before. 
- I've removed all checks on files as they do not make sense, since zmcertmgr will take care of them
- zmcertmgr is run through ProcessBuilder and the API waits for it to exit
- zmcertmgr output is checked against "error" string being present.
- Made repo changes to use ibiblio to resolve artifacts from maven, so we can transitive download dependecies
- Add ivy configuration to download maven artifacts using default conf
- Added test to check validity return value against some mocked process output

### Additional notes
Tested the API in a real server and behaves as it should.
Still missing a test where we have to provide a valid chain certificate from a valid authority and not self signed