### PR TITLE
chore: maven central first repo to improve build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
 
   <repositories>
     <repository>
+      <id>maven</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
       <id>zextras-java-sdk</id>
       <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
     </repository>


### PR DESCRIPTION
# Motivation
Adding external repositories increases build time a lot. It also doubles build time of entire Carbonio.
If you execute mvn:effective-pom you will see maven central repo is last in order.
Since majority of packages comes from central it would be better to have it first.

# What's changed
Put maven central repo as first.
