### PR TITLE
chore(jenkinsfile): use jenkins settings as credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def mvnCmd(String cmd) {
-  sh 'mvn -B -s settings.xml ' + cmd
+  sh 'mvn -B -s settings-jenkins.xml ' + cmd
 }
 
 pipeline {
@@ -12,7 +12,6 @@ pipeline {
         JAVA_OPTS = '-Dfile.encoding=UTF8'
         LC_ALL = 'C.UTF-8'
         ARTIFACTORY_ACCESS=credentials('artifactory-jenkins-gradle-properties-splitted')
-        BUILD_PROPERTIES_PARAMS='-Dartifactory_user=$ARTIFACTORY_ACCESS_USR -Dartifactory_password=$ARTIFACTORY_ACCESS_PSW'
         jenkins_build = 'true'
     }
     options {
@@ -24,13 +23,25 @@ pipeline {
         stage('Checkout') {
             steps {
                 checkout scm
+                withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
+                  sh "cp ${SETTINGS_PATH} settings-jenkins.xml"
+                }
             }
         }
         stage('Build with tests') {
             steps {
-              mvnCmd("$BUILD_PROPERTIES_PARAMS clean verify")
+              mvnCmd("clean verify")
               publishCoverage adapters: [jacocoAdapter(path: '**/target/site/jacoco/jacoco.xml')], calculateDiffForChangeRequests: true, failNoReports: true
               junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml'
+            }
+        }
+
+        stage('Publish SNAPSHOT to maven') {
+            when {
+                branch 'devel'
+            }
+            steps {
+                mvnCmd("deploy -Pdev")
             }
         }
 
@@ -39,7 +50,7 @@ pipeline {
                 buildingTag()
             }
             steps {
-                mvnCmd("$BUILD_PROPERTIES_PARAMS deploy")
+                mvnCmd("deploy -Pprod")
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     environment {
         JAVA_OPTS = '-Dfile.encoding=UTF8'
         LC_ALL = 'C.UTF-8'
-        ARTIFACTORY_ACCESS=credentials('artifactory-jenkins-gradle-properties-splitted')
         jenkins_build = 'true'
     }
     options {

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,22 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>prod</id>
+      <distributionManagement>
+        <repository>
+          <id>artifactory</id>
+          <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
+        </repository>
+      </distributionManagement>
+    </profile>
   </profiles>
 
   <distributionManagement>
-    <repository>
-      <id>zextras-java-sdk</id>
-      <url>https://zextras.jfrog.io/artifactory/public-maven-repo</url>
-    </repository>
+    <snapshotRepository>
+      <id>artifactory</id>
+      <url>https://zextras.jfrog.io/artifactory/maven-snapshot</url>
+    </snapshotRepository>
   </distributionManagement>
 
   <repositories>


### PR DESCRIPTION
This PR fixes deploy on Zextras maven because of credentials permission.
Also it will deploy on public repo or snapshot one based on active profile so we avoid accidental deploy.